### PR TITLE
chore(release): adopt Landfall

### DIFF
--- a/.github/workflows/landfall-release.yml
+++ b/.github/workflows/landfall-release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: misty-step/landfall@v1
         with:
           mode: synthesis-only
-          healthcheck: "true"
+          healthcheck: 'true'
           release-tag: ${{ github.event.release.tag_name }}
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/landfall-release.yml
+++ b/.github/workflows/landfall-release.yml
@@ -1,0 +1,31 @@
+name: Synthesize Release Notes
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          healthcheck: "true"
+          release-tag: ${{ github.event.release.tag_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          product-description: Release notes and changelog automation for phrazzld/timeismoney.
+          audience: developer
+          voice-guide: clear, concrete, and specific to shipped behavior
+          changelog-source: auto
+          notes-output-file: docs/releases/{version}.md
+          notes-output-json: docs/releases/releases.json

--- a/.landfall.yml
+++ b/.landfall.yml
@@ -1,0 +1,23 @@
+product:
+  name: Timeismoney
+  description: Release notes and changelog automation for phrazzld/timeismoney.
+audience: developer
+voice: clear, concrete, and specific to shipped behavior
+changelog:
+  source: auto
+artifacts:
+  markdown: docs/releases/{version}.md
+  plaintext: null
+  html: null
+  json: docs/releases/releases.json
+  rss: null
+release:
+  profile: synthesis-only
+model:
+  policy: balanced
+  primary: null
+  fallbacks: []
+budget:
+  max_input_tokens: 12000
+  max_output_tokens: 1200
+  max_usd: null


### PR DESCRIPTION
Adopt Landfall using the reviewed fleet rollout receipt.

This adds:
- `.landfall.yml` product/release metadata
- `.github/workflows/landfall-release.yml` synthesis-only release-note generation after GitHub releases are published

Rollout receipt: `.landfall/org-rollout/github-ready-prs/phrazzld_timeismoney/phrazzld__timeismoney`

Monitor the first downstream release run before extending this pattern further.
